### PR TITLE
Force recent MFA login by victim

### DIFF
--- a/server.js
+++ b/server.js
@@ -183,6 +183,7 @@ async function fetchDeviceCode() {
     const data = new URLSearchParams({
         'client_id': config.clientId,
         'scope': config.scopes,
+        'claims': '{"access_token": {"amr": {"values": ["ngcmfa", "mfa"]}}}',
     });
     const response = await fetch(config.deviceCodeUrl, buildPostRequest(data));
     if (response.status !== 200) {


### PR DESCRIPTION
This adds the `ngcmfa` claim when initiating the device code flow.

The underlying request should be identical to what Dirk-jan eventually implemented for `roadtx auth --device-code --force-ngcmfa ...` in response to [my initial pull request](https://github.com/dirkjanm/ROADtools/pull/115).